### PR TITLE
Add TypeScript exec examples and update SDK to 0.3.0

### DIFF
--- a/typescript/exec/main.ts
+++ b/typescript/exec/main.ts
@@ -1,0 +1,75 @@
+import { createClient } from "@connectrpc/connect";
+import { createConnectTransport } from "@connectrpc/connect-node";
+import { Timestamp } from "@bufbuild/protobuf";
+import { loadDefaults } from "@namespacelabs/sdk/auth";
+import { createComputeClient } from "@namespacelabs/sdk/api/compute";
+import { bearerAuthInterceptor } from "@namespacelabs/sdk/api";
+import { CommandService } from "@namespacelabs/sdk/proto/namespace/cloud/compute/v1beta/command_connect";
+
+void main();
+
+async function main() {
+	const tokenSource = await loadDefaults();
+
+	const api = createComputeClient({ tokenSource });
+
+	const start = Date.now();
+
+	// Create an instance with an ubuntu container.
+	const resp = await api.compute.createInstance({
+		shape: { virtualCpu: 2, memoryMegabytes: 4096, machineArch: "amd64" },
+		documentedPurpose: "exec example",
+		deadline: Timestamp.fromDate(new Date(Date.now() + 10 * 60 * 1000)),
+		containers: [
+			{
+				name: "ubuntu",
+				imageRef: "ubuntu:latest",
+				args: ["sleep", "600"],
+			},
+		],
+	});
+
+	const instanceId = resp.metadata!.instanceId;
+	console.error(`[namespace] Instance: ${resp.instanceUrl}`);
+	console.error(JSON.stringify(resp.toJson(), null, 2));
+
+	const endpoint = resp.extendedMetadata?.commandServiceEndpoint;
+	if (!endpoint) {
+		throw new Error("command service endpoint not available");
+	}
+
+	console.error(`[namespace] Command service endpoint: ${endpoint}`);
+
+	// Connect to the CommandService on the instance.
+	const cmdTransport = createConnectTransport({
+		httpVersion: "1.1",
+		baseUrl: endpoint,
+		useBinaryFormat: false,
+		interceptors: [bearerAuthInterceptor(tokenSource)],
+	});
+
+	const cmdClient = createClient(CommandService, cmdTransport);
+
+	const result = await cmdClient.runCommandSync({
+		instanceId,
+		targetContainerName: "ubuntu",
+		command: {
+			command: ["uname", "-a"],
+		},
+	});
+
+	const elapsed = Date.now() - start;
+	console.error(
+		`[namespace] Total time from CreateInstance to command result: ${elapsed}ms`
+	);
+
+	const decoder = new TextDecoder();
+	process.stdout.write(decoder.decode(result.stdout));
+	if (result.stderr.length > 0) {
+		process.stderr.write(decoder.decode(result.stderr));
+	}
+
+	if (result.exitCode !== 0) {
+		throw new Error(`command exited with code ${result.exitCode}`);
+	}
+}

--- a/typescript/nosdk/exec/main.ts
+++ b/typescript/nosdk/exec/main.ts
@@ -1,0 +1,138 @@
+// This example demonstrates how to use the Namespace Compute API without the
+// @namespacelabs/sdk package, using only fetch and the Connect protocol (JSON).
+//
+// WARNING: This example loads a bearer token directly from NSC_TOKEN_FILE.
+// This is NOT recommended for production use. Bearer tokens expire and need to
+// be refreshed. Use the @namespacelabs/sdk package instead, which handles token
+// lifecycle (session tokens, caching, refresh) automatically.
+
+import * as fs from "fs/promises";
+
+const REGION = "us";
+const COMPUTE_API = `https://${REGION}.compute.namespaceapis.com`;
+
+interface TokenJson {
+	bearer_token: string;
+	session_token?: string;
+}
+
+async function loadBearerToken(): Promise<string> {
+	const tokenFile = process.env.NSC_TOKEN_FILE;
+	if (!tokenFile) {
+		throw new Error(
+			"NSC_TOKEN_FILE environment variable is not set. " +
+				"Point it to a token.json file (e.g. from `nsc login`)."
+		);
+	}
+
+	const content = await fs.readFile(tokenFile, "utf8");
+	const tokenJson: TokenJson = JSON.parse(content);
+	if (!tokenJson.bearer_token) {
+		throw new Error("Token file does not contain a bearer_token");
+	}
+	return tokenJson.bearer_token;
+}
+
+// Make a Connect (JSON) unary RPC call using fetch.
+async function connectCall(
+	baseUrl: string,
+	service: string,
+	method: string,
+	token: string,
+	body: unknown
+): Promise<unknown> {
+	const url = `${baseUrl}/${service}/${method}`;
+	const res = await fetch(url, {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+			Authorization: `Bearer ${token}`,
+		},
+		body: JSON.stringify(body),
+	});
+
+	if (!res.ok) {
+		const text = await res.text();
+		throw new Error(`${method} failed (${res.status}): ${text}`);
+	}
+
+	return await res.json();
+}
+
+void main();
+
+async function main() {
+	const token = await loadBearerToken();
+
+	const start = Date.now();
+
+	// Create an instance with an ubuntu container.
+	const createResp = (await connectCall(
+		COMPUTE_API,
+		"namespace.cloud.compute.v1beta.ComputeService",
+		"CreateInstance",
+		token,
+		{
+			shape: { virtualCpu: 2, memoryMegabytes: 4096, machineArch: "amd64" },
+			documentedPurpose: "exec example (no-sdk)",
+			deadline: new Date(Date.now() + 10 * 60 * 1000).toISOString(),
+			containers: [
+				{
+					name: "ubuntu",
+					imageRef: "ubuntu:latest",
+					args: ["sleep", "600"],
+				},
+			],
+		}
+	)) as {
+		instanceUrl: string;
+		metadata: { instanceId: string };
+		extendedMetadata?: { commandServiceEndpoint?: string };
+	};
+
+	const instanceId = createResp.metadata.instanceId;
+	console.error(`[namespace] Instance: ${createResp.instanceUrl}`);
+	console.error(JSON.stringify(createResp, null, 2));
+
+	const endpoint = createResp.extendedMetadata?.commandServiceEndpoint;
+	if (!endpoint) {
+		throw new Error("command service endpoint not available");
+	}
+
+	console.error(`[namespace] Command service endpoint: ${endpoint}`);
+
+	// Run a command in the container via the CommandService.
+	const result = (await connectCall(
+		endpoint,
+		"namespace.cloud.compute.v1beta.CommandService",
+		"RunCommandSync",
+		token,
+		{
+			instanceId,
+			targetContainerName: "ubuntu",
+			command: {
+				command: ["uname", "-a"],
+			},
+		}
+	)) as {
+		stdout?: string; // base64-encoded
+		stderr?: string; // base64-encoded
+		exitCode?: number;
+	};
+
+	const elapsed = Date.now() - start;
+	console.error(
+		`[namespace] Total time from CreateInstance to command result: ${elapsed}ms`
+	);
+
+	if (result.stdout) {
+		process.stdout.write(Buffer.from(result.stdout, "base64"));
+	}
+	if (result.stderr) {
+		process.stderr.write(Buffer.from(result.stderr, "base64"));
+	}
+
+	if (result.exitCode && result.exitCode !== 0) {
+		throw new Error(`command exited with code ${result.exitCode}`);
+	}
+}

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -9,195 +9,13 @@
 				"@bufbuild/protobuf": "^1.10.0",
 				"@connectrpc/connect": "^1.7.0",
 				"@connectrpc/connect-node": "^1.7.0",
-				"@namespacelabs/sdk": "^0.1.0",
+				"@namespacelabs/sdk": "^0.3.0",
 				"jsonwebtoken": "^9.0.2"
 			},
 			"devDependencies": {
 				"@types/jsonwebtoken": "^9.0.4",
 				"tsx": "^4.20.6"
 			}
-		},
-		"../../typescript-sdk": {
-			"name": "@namespacelabs/sdk",
-			"version": "0.1.0",
-			"license": "Apache-2.0",
-			"devDependencies": {
-				"@bufbuild/protobuf": "^1.10.0",
-				"@connectrpc/connect": "^1.7.0",
-				"@connectrpc/connect-node": "^1.7.0",
-				"@types/node": "^20.17.10",
-				"tsx": "^4.20.6",
-				"typescript": "^5.7.2"
-			},
-			"peerDependencies": {
-				"@bufbuild/protobuf": "^1.10.0",
-				"@connectrpc/connect": "^1.0.0",
-				"@connectrpc/connect-node": "^1.0.0"
-			}
-		},
-		"../../typescript-sdk/node_modules/@bufbuild/protobuf": {
-			"version": "1.10.1",
-			"dev": true,
-			"license": "(Apache-2.0 AND BSD-3-Clause)"
-		},
-		"../../typescript-sdk/node_modules/@connectrpc/connect": {
-			"version": "1.7.0",
-			"dev": true,
-			"license": "Apache-2.0",
-			"peerDependencies": {
-				"@bufbuild/protobuf": "^1.10.0"
-			}
-		},
-		"../../typescript-sdk/node_modules/@connectrpc/connect-node": {
-			"version": "1.7.0",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"undici": "^5.28.4"
-			},
-			"engines": {
-				"node": ">=16.0.0"
-			},
-			"peerDependencies": {
-				"@bufbuild/protobuf": "^1.10.0",
-				"@connectrpc/connect": "1.7.0"
-			}
-		},
-		"../../typescript-sdk/node_modules/@esbuild/linux-x64": {
-			"version": "0.25.11",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"../../typescript-sdk/node_modules/@fastify/busboy": {
-			"version": "2.1.1",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=14"
-			}
-		},
-		"../../typescript-sdk/node_modules/@types/node": {
-			"version": "20.19.22",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"undici-types": "~6.21.0"
-			}
-		},
-		"../../typescript-sdk/node_modules/esbuild": {
-			"version": "0.25.11",
-			"dev": true,
-			"hasInstallScript": true,
-			"license": "MIT",
-			"bin": {
-				"esbuild": "bin/esbuild"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"optionalDependencies": {
-				"@esbuild/aix-ppc64": "0.25.11",
-				"@esbuild/android-arm": "0.25.11",
-				"@esbuild/android-arm64": "0.25.11",
-				"@esbuild/android-x64": "0.25.11",
-				"@esbuild/darwin-arm64": "0.25.11",
-				"@esbuild/darwin-x64": "0.25.11",
-				"@esbuild/freebsd-arm64": "0.25.11",
-				"@esbuild/freebsd-x64": "0.25.11",
-				"@esbuild/linux-arm": "0.25.11",
-				"@esbuild/linux-arm64": "0.25.11",
-				"@esbuild/linux-ia32": "0.25.11",
-				"@esbuild/linux-loong64": "0.25.11",
-				"@esbuild/linux-mips64el": "0.25.11",
-				"@esbuild/linux-ppc64": "0.25.11",
-				"@esbuild/linux-riscv64": "0.25.11",
-				"@esbuild/linux-s390x": "0.25.11",
-				"@esbuild/linux-x64": "0.25.11",
-				"@esbuild/netbsd-arm64": "0.25.11",
-				"@esbuild/netbsd-x64": "0.25.11",
-				"@esbuild/openbsd-arm64": "0.25.11",
-				"@esbuild/openbsd-x64": "0.25.11",
-				"@esbuild/openharmony-arm64": "0.25.11",
-				"@esbuild/sunos-x64": "0.25.11",
-				"@esbuild/win32-arm64": "0.25.11",
-				"@esbuild/win32-ia32": "0.25.11",
-				"@esbuild/win32-x64": "0.25.11"
-			}
-		},
-		"../../typescript-sdk/node_modules/get-tsconfig": {
-			"version": "4.12.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"resolve-pkg-maps": "^1.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
-			}
-		},
-		"../../typescript-sdk/node_modules/resolve-pkg-maps": {
-			"version": "1.0.0",
-			"dev": true,
-			"license": "MIT",
-			"funding": {
-				"url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
-			}
-		},
-		"../../typescript-sdk/node_modules/tsx": {
-			"version": "4.20.6",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"esbuild": "~0.25.0",
-				"get-tsconfig": "^4.7.5"
-			},
-			"bin": {
-				"tsx": "dist/cli.mjs"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			},
-			"optionalDependencies": {
-				"fsevents": "~2.3.3"
-			}
-		},
-		"../../typescript-sdk/node_modules/typescript": {
-			"version": "5.9.3",
-			"dev": true,
-			"license": "Apache-2.0",
-			"bin": {
-				"tsc": "bin/tsc",
-				"tsserver": "bin/tsserver"
-			},
-			"engines": {
-				"node": ">=14.17"
-			}
-		},
-		"../../typescript-sdk/node_modules/undici": {
-			"version": "5.29.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@fastify/busboy": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=14.0"
-			}
-		},
-		"../../typescript-sdk/node_modules/undici-types": {
-			"version": "6.21.0",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/@bufbuild/protobuf": {
 			"version": "1.10.1",
@@ -247,8 +65,15 @@
 			}
 		},
 		"node_modules/@namespacelabs/sdk": {
-			"resolved": "../../typescript-sdk",
-			"link": true
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/@namespacelabs/sdk/-/sdk-0.3.0.tgz",
+			"integrity": "sha512-NCo7ZC6iGwDY9ujYLlOp7RG1WbLMgYqoWyqNXGJvBHuXNtfZ5tDR66RWCpVFnYriit6lkjdgSf5UMgbMMNVQ/w==",
+			"license": "Apache-2.0",
+			"peerDependencies": {
+				"@bufbuild/protobuf": "^1.10.0",
+				"@connectrpc/connect": "^1.0.0",
+				"@connectrpc/connect-node": "^1.0.0"
+			}
 		},
 		"node_modules/@types/jsonwebtoken": {
 			"version": "9.0.4",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -5,13 +5,15 @@
 		"containers-demo": "tsx containers-demo/main.ts",
 		"kubernetes-demo": "tsx kubernetes-demo/main.ts",
 		"iam-demo": "tsx iam-demo/main.ts",
-		"macos-app-demo": "tsx macos-app-demo/main.ts"
+		"macos-app-demo": "tsx macos-app-demo/main.ts",
+		"exec": "tsx exec/main.ts",
+		"nosdk-exec": "tsx nosdk/exec/main.ts"
 	},
 	"dependencies": {
 		"@bufbuild/protobuf": "^1.10.0",
 		"@connectrpc/connect": "^1.7.0",
 		"@connectrpc/connect-node": "^1.7.0",
-		"@namespacelabs/sdk": "^0.1.0",
+		"@namespacelabs/sdk": "^0.3.0",
 		"jsonwebtoken": "^9.0.2"
 	},
 	"devDependencies": {


### PR DESCRIPTION
## Changes

- **Update `@namespacelabs/sdk`** from `0.2.0` to `0.3.0` (adds `CommandService` proto support)
- **Add `typescript/exec/`**: TypeScript port of `go/exec` using the SDK — creates an instance, connects to the command service, and runs `uname -a`
- **Add `typescript/nosdk/exec/`**: Same example using only `fetch` and the Connect JSON protocol (no SDK dependency, loads token from `NSC_TOKEN_FILE`)

Both examples have been tested end-to-end successfully.