### PR TITLE
Add unique instance cache example

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The Go examples are located in the `go/` directory. Each example demonstrates di
 | **createinstance** | Creating compute instances with specific configurations and running containers |
 | **createpartnerinstance** | AWS identity federation with Namespace and creating instances with federated credentials |
 | **ensuretenant** | Creating and managing tenants using AWS federation for identity management |
+| **ensurewithcache** | Creating or reusing a uniquely tagged instance with a cache volume |
 | **buildandrun** | Complete workflow: build image, create instance, run service, and connect via gRPC |
 | **macrun** | Building and running Go applications on macOS/ARM64 instances |
 | **sidecar** | Advanced instance configuration with sidecar containers and SSH access |
@@ -54,6 +55,9 @@ Demonstrates AWS identity federation with Namespace and creating instances with 
 
 #### ensuretenant
 Shows how to create and manage tenants using AWS federation for identity management.
+
+#### ensurewithcache
+Shows how to create or reuse an instance with a unique tag and attach a cache volume that can be restored across instance lifetimes.
 
 #### buildandrun
 Complete end-to-end example: build a Docker image, create an instance, run a gRPC service, and connect to it.

--- a/go/ensurewithcache/ensurewithcache.go
+++ b/go/ensurewithcache/ensurewithcache.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	computepb "buf.build/gen/go/namespace/cloud/protocolbuffers/go/proto/namespace/cloud/compute/v1beta"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"namespacelabs.dev/integrations/api"
+	"namespacelabs.dev/integrations/api/compute"
+	"namespacelabs.dev/integrations/auth"
+)
+
+var (
+	uniqueTag = flag.String("unique_tag", "ensure-with-cache", "Unique tag used to create or reuse the instance.")
+	cacheTag  = flag.String("cache_tag", "ensure-with-cache-data", "Tag used to restore the cache volume across instance lifetimes.")
+	deadline  = flag.Duration("deadline", time.Hour, "How long a newly created instance should run.")
+)
+
+func main() {
+	flag.Parse()
+
+	token, err := auth.LoadDefaults()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	endpoint, err := ensure(context.Background(), token)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Fprintf(os.Stdout, "https://%s\n", endpoint)
+}
+
+func ensure(ctx context.Context, token api.TokenSource) (string, error) {
+	cli, err := compute.NewClient(ctx, token)
+	if err != nil {
+		return "", err
+	}
+	defer cli.Close()
+
+	// Repeating this request with the same unique tag returns the running instance instead of creating another one.
+	resp, err := cli.Compute.CreateInstance(ctx, &computepb.CreateInstanceRequest{
+		Shape: &computepb.InstanceShape{
+			VirtualCpu:      2,
+			MemoryMegabytes: 4 * 1024,
+			MachineArch:     "amd64",
+			Os:              "linux",
+		},
+		DocumentedPurpose: "ensurewithcache example",
+		Deadline:          timestamppb.New(time.Now().Add(*deadline)),
+		Experimental: &computepb.CreateInstanceRequest_ExperimentalFeatures{
+			UniqueTag: *uniqueTag,
+		},
+		Containers: []*computepb.ContainerRequest{{
+			Name:       "server",
+			ImageRef:   "alpine:3.21",
+			Entrypoint: []string{"/bin/sh", "-c"},
+			Args: []string{`if [ ! -f /cache/index.html ]; then
+  printf 'cache initialized by %s at %s\n' "$HOSTNAME" "$(date -u +%FT%TZ)" > /cache/index.html
+fi
+exec httpd -f -p 8080 -h /cache`},
+			// A later instance can best-effort restore the latest committed volume carrying this cache tag.
+			Volumes: []*computepb.VolumeRequest{{
+				MountPoint:      "/cache",
+				Tag:             *cacheTag,
+				SizeMb:          1024,
+				PersistencyKind: computepb.VolumeRequest_CACHE,
+			}},
+			ExportPorts: []*computepb.ContainerPort{{
+				Name:          "http",
+				ContainerPort: 8080,
+				Proto:         computepb.ContainerPort_HTTP,
+			}},
+		}},
+	})
+	if err != nil {
+		return "", err
+	}
+
+	if _, err := cli.Compute.WaitInstanceSync(ctx, &computepb.WaitInstanceRequest{
+		InstanceId: resp.Metadata.InstanceId,
+	}); err != nil {
+		return "", err
+	}
+
+	for _, container := range resp.Containers {
+		if container.Name != "server" {
+			continue
+		}
+		for _, port := range container.ExportedPort {
+			if port.ContainerPort == 8080 && port.Proto == computepb.ContainerPort_HTTP {
+				fmt.Fprintf(os.Stderr, "[namespace] Ensured instance: %s\n", resp.InstanceUrl)
+				return port.Endpoint, nil
+			}
+		}
+	}
+
+	return "", fmt.Errorf("HTTP endpoint was not allocated")
+}

--- a/go/ensurewithcache/ensurewithcache.go
+++ b/go/ensurewithcache/ensurewithcache.go
@@ -72,6 +72,7 @@ exec httpd -f -p 8080 -h /cache`},
 				SizeMb:          1024,
 				PersistencyKind: computepb.VolumeRequest_CACHE,
 			}},
+			// HTTP ingress requires Namespace authentication by default. See https://namespace.so/docs/architecture/networking/ingress#access-controls.
 			ExportPorts: []*computepb.ContainerPort{{
 				Name:          "http",
 				ContainerPort: 8080,

--- a/go/ensurewithcache/ensurewithcache.go
+++ b/go/ensurewithcache/ensurewithcache.go
@@ -59,7 +59,7 @@ func ensure(ctx context.Context, token api.TokenSource) (string, error) {
 		},
 		Containers: []*computepb.ContainerRequest{{
 			Name:       "server",
-			ImageRef:   "alpine:3.21",
+			ImageRef:   "busybox:1.37@sha256:9db7b59979c38555a39def84a31fb98b5296952f9e3afd4f6f11f05b07adfab0",
 			Entrypoint: []string{"/bin/sh", "-c"},
 			Args: []string{`if [ ! -f /cache/index.html ]; then
   printf 'cache initialized by %s at %s\n' "$HOSTNAME" "$(date -u +%FT%TZ)" > /cache/index.html


### PR DESCRIPTION
## Summary

- Adds a Go example that creates or reuses an instance using a unique tag.
- Attaches a tagged cache volume and serves cache-backed content over authenticated HTTP ingress.
- Documents the example and links to ingress access controls.

## Validation

- `go test ./...`
- Ran the cache-backed BusyBox HTTP server locally and fetched its generated marker.
- Ran the example twice against Namespace with the same tags; both calls reused the same instance and endpoint and returned the same cached marker.